### PR TITLE
Fix parentheses

### DIFF
--- a/src/epub/text/act-2.xhtml
+++ b/src/epub/text/act-2.xhtml
@@ -233,7 +233,7 @@
 					</tr>
 					<tr>
 						<td epub:type="z3998:persona">Helena</td>
-						<td>Ten years? Today? Why⁠—<i epub:type="z3998:stage-direction">They embrace.</i>)</td>
+						<td>Ten years? Today? Why⁠—<i epub:type="z3998:stage-direction">They embrace.</i></td>
 					</tr>
 					<tr>
 						<td epub:type="z3998:persona">Nana</td>

--- a/src/epub/text/act-3.xhtml
+++ b/src/epub/text/act-3.xhtml
@@ -84,7 +84,7 @@
 					</tr>
 					<tr>
 						<td epub:type="z3998:persona">Hallemeier</td>
-						<td><i epub:type="z3998:stage-direction">Crosses to window.</i>) We’ve barricaded the passages and the stairs. <i epub:type="z3998:stage-direction">Going to window.</i> God, what swarms of them. I don’t like the looks of them, Domin. There’s a feeling of death about it all. Any water here?</td>
+						<td><i epub:type="z3998:stage-direction">Crosses to window.</i> We’ve barricaded the passages and the stairs. <i epub:type="z3998:stage-direction">Going to window.</i> God, what swarms of them. I don’t like the looks of them, Domin. There’s a feeling of death about it all. Any water here?</td>
 					</tr>
 					<tr>
 						<td epub:type="z3998:persona">Fabry</td>


### PR DESCRIPTION
Fixing 2 places in the text where, when viewed, there are 2 closing parentheses due to having both a stage direction type and a parenthesis in the text.

<img width="459" height="66" alt="image" src="https://github.com/user-attachments/assets/01e5a5d8-b08a-4c51-9b64-101f6194221f" />

<img width="624" height="65" alt="image" src="https://github.com/user-attachments/assets/67484f86-e998-415f-8334-a8aa69f1a76a" />
